### PR TITLE
Fix bug in block-listener crawler

### DIFF
--- a/crawlers/block-listener.js
+++ b/crawlers/block-listener.js
@@ -63,7 +63,7 @@ async function main () {
     const blockAuthorName = blockAuthorIdentity.identity.display || ``;
 
     // Get runtime spec name and version
-    const runtimeVersion = await api.rpc.state.getRuntimeVersion();
+    const runtimeVersion = await api.rpc.state.getRuntimeVersion(blockHash);
 
     // Get session info
     const session = await api.derive.session.info();


### PR DESCRIPTION
Fix bug in block-listener crawler. 

```
listener_1        | [PolkaStats backend v3] - Block listener - Adding block #141 [0x1c41954dc7cbb594f6bb46845b67946b9690dc7761b255de159693fc95577928]
postgres_1        | 2020-02-21 17:49:40.914 UTC [91] ERROR:  null value in column "spec_name" violates not-null constraint
postgres_1        | 2020-02-21 17:49:40.914 UTC [91] DETAIL:  Failing row contains (141, DtbB3Uy8zX9khHRf7SsSVk7esY5AngKvC9EJVhpjSzza2MU, , 0x1c41954dc7cbb594f6bb46845b67946b9690dc7761b255de159693fc955779..., 0xaae996f6198a76723eaba58215f8852b0132c96400a1bcddaab0de80ec1293..., 0x8801e6f09eeb08b2cbadb562daf1b44f547d69ce861e7c5c157a6735d5799a..., 0x3b35f71303ddac845a63f8d9f1114dd8a22283d329bb92a15dfa2c36dd81fd..., 0, 0, 3600, 150, t, 600, 6, 150, 50, null, null, 1582307380911).
postgres_1        | 2020-02-21 17:49:40.914 UTC [91] STATEMENT:  INSERT INTO block (
postgres_1        |               block_number,
postgres_1        |               block_author,
postgres_1        |               block_author_name,
postgres_1        |               block_hash,
postgres_1        |               parent_hash,
postgres_1        |               extrinsics_root,
postgres_1        |               state_root,
postgres_1        |               current_era,
postgres_1        |               current_index,
postgres_1        |               era_length,
postgres_1        |               era_progress,
postgres_1        |               is_epoch,
postgres_1        |               session_length,
postgres_1        |               session_per_era,
postgres_1        |               session_progress,
postgres_1        |               validator_count,
postgres_1        |               timestamp
postgres_1        |             ) VALUES (
postgres_1        |               '141',
postgres_1        |               'DtbB3Uy8zX9khHRf7SsSVk7esY5AngKvC9EJVhpjSzza2MU',
postgres_1        |               '',
postgres_1        |               '0x1c41954dc7cbb594f6bb46845b67946b9690dc7761b255de159693fc95577928',
postgres_1        |               '0xaae996f6198a76723eaba58215f8852b0132c96400a1bcddaab0de80ec1293ea',
postgres_1        |               '0x8801e6f09eeb08b2cbadb562daf1b44f547d69ce861e7c5c157a6735d5799ae2',
postgres_1        |               '0x3b35f71303ddac845a63f8d9f1114dd8a22283d329bb92a15dfa2c36dd81fdd4',
postgres_1        |               '0',
postgres_1        |               '0',
postgres_1        |               '3600',
postgres_1        |               '150',
postgres_1        |               'true',
postgres_1        |               '600',
postgres_1        |               '6',
postgres_1        |               '150',
postgres_1        |               '50',
postgres_1        |               '1582307380911'
postgres_1        |             )
listener_1        | (node:1) UnhandledPromiseRejectionWarning: error: null value in column "spec_name" violates not-null constraint
listener_1        |     at Connection.parseE (/usr/app/polkastats-backend-v3/node_modules/pg/lib/connection.js:614:13)
listener_1        |     at Connection.parseMessage (/usr/app/polkastats-backend-v3/node_modules/pg/lib/connection.js:413:19)
listener_1        |     at Socket.<anonymous> (/usr/app/polkastats-backend-v3/node_modules/pg/lib/connection.js:129:22)
listener_1        |     at Socket.emit (events.js:223:5)
listener_1        |     at addChunk (_stream_readable.js:309:12)
listener_1        |     at readableAddChunk (_stream_readable.js:290:11)
listener_1        |     at Socket.Readable.push (_stream_readable.js:224:10)
listener_1        |     at TCP.onStreamRead (internal/stream_base_commons.js:181:23)
listener_1        | (node:1) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
listener_1        | (node:1) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```