### PR TITLE
Ana/add ports to postgres docker

### DIFF
--- a/docker/polkastats-backend/docker-compose.yml
+++ b/docker/polkastats-backend/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - '5434:5432'
   #
   # Hasura
   #


### PR DESCRIPTION
Closes #ISSUE

**Description:**

<!-- Briefly describe what you're adding or fixing with this PR -->
Many developers use Postgres nowadays and it will go for them like it went for me. Port 5432 will be busy and they won't get any data saved in the Hasura.

Better have a different port for our Postgres container.

Thank you! 🚀

---

For contributor:

- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI