### PR TITLE
Upgrade polkadot to v.0.7.28

### DIFF
--- a/docker/polkastats-backend/substrate-client/Dockerfile
+++ b/docker/polkastats-backend/substrate-client/Dockerfile
@@ -2,7 +2,7 @@ FROM phusion/baseimage:0.11
 LABEL maintainer "@ColmenaLabs_svq"
 LABEL description="Small image with the Substrate binary."
 
-ARG VERSION=v0.7.27
+ARG VERSION=v0.7.28
 
 RUN apt-get update && apt-get install wget curl jq -y
 


### PR DESCRIPTION
Closes #107 

**Description:**

Upgrade polkadot to v.0.7.28

Thank you! 🚀

---

For contributor:

- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI