### PR TITLE
Fix crawlers base image version

### DIFF
--- a/docker/polkastats-backend/backend/Dockerfile
+++ b/docker/polkastats-backend/backend/Dockerfile
@@ -8,7 +8,7 @@
 #
 #RUN cargo build --release
 
-FROM node
+FROM node:erbium
 
 WORKDIR /usr/app/polkastats-backend-v3
 


### PR DESCRIPTION
**Description:**

Use current node LTS (erbium) to avoid future breaking changes from node. 

This PR should fix #136 since the error caused by some issue with node-postgres package being not yet compatible with node 14 (https://github.com/brianc/node-postgres/issues/2181).

---

For contributor:

- [x] Reviewed `Files changed` in the github PR explorer

For reviewer:

- [ ] Manually tested the changes on the UI