### PR TITLE
Store validator and nominator slashes in db

### DIFF
--- a/backend.config.js
+++ b/backend.config.js
@@ -55,7 +55,7 @@ module.exports = {
 
     {
       enabled: !process.env.CRAWLER_REWARDS_DISABLE,
-      module: require('./lib/crawlers/rewards'),
+      module: require('./lib/crawlers/rewardsSlashes'),
     },
 
     {

--- a/docker/polkastats-backend/sql/polkastats.sql
+++ b/docker/polkastats-backend/sql/polkastats.sql
@@ -57,6 +57,24 @@ CREATE TABLE IF NOT EXISTS rewards  (
   PRIMARY KEY ( block_number, era_index, stash_id )  
 );
 
+CREATE TABLE IF NOT EXISTS validator_slashes_era  (
+  block_number BIGINT NOT NULL,
+  era_index INT NOT NULL,
+  account_id VARCHAR(50),
+  amount BIGINT NOT NULL,
+  timestamp BIGINT NOT NULL,
+  PRIMARY KEY ( block_number, era_index, account_id )  
+);
+
+CREATE TABLE IF NOT EXISTS nominator_slashes_era  (
+  block_number BIGINT NOT NULL,
+  era_index INT NOT NULL,
+  account_id VARCHAR(50),
+  amount BIGINT NOT NULL,
+  timestamp BIGINT NOT NULL,
+  PRIMARY KEY ( block_number, era_index, account_id )  
+);
+
 CREATE TABLE IF NOT EXISTS validator_staking  (  
   block_number BIGINT NOT NULL,
   session_index INT NOT NULL,

--- a/lib/crawlers/rewardsSlashes.js
+++ b/lib/crawlers/rewardsSlashes.js
@@ -23,7 +23,7 @@ module.exports = {
       currentDBEraIndex = currentEraIndex;
       const block = await api.rpc.chain.getBlock()
       const blockNumber = block.block.header.number.toNumber()
-      await module.exports.storeRewardsInfo(api, pool, blockNumber, currentEraIndex);
+      await module.exports.storeEraRewardsSlashes(api, pool, blockNumber, currentEraIndex);
     }
 
     // Subscribe to new blocks
@@ -40,21 +40,51 @@ module.exports = {
 
       if (currentEraIndex > currentDBEraIndex) {
         currentDBEraIndex = currentEraIndex;
-        await module.exports.storeRewardsInfo(api, pool, blockNumber, currentEraIndex);
+        await module.exports.storeEraRewardsSlashes(api, pool, blockNumber, currentEraIndex);
       }
     });
   },
-  storeRewardsInfo: async function (api, pool, blockNumber, currentEraIndex) {
+  storeEraRewardsSlashes: async function (api, pool, blockNumber, currentEraIndex) {
 
     //
-    // We want the rewards for the LAST era
+    // We want the rewards and slashes for the LAST era
     //
     const eraIndex = currentEraIndex - 1;
     console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[32mStoring rewards at block #${blockNumber} for era #${eraIndex}\x1b[0m`);
 
-    // Get last era rewards
-    let eraRewards = await api.query.staking.erasValidatorReward(eraIndex);
-    // console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[32mRewards for era #${eraIndex}: ${JSON.stringify(eraRewards, null, 2)}\x1b[0m`);
+    // Get Validator rewards for last era
+    const eraRewards = await api.query.staking.erasValidatorReward(eraIndex);
+
+    // Fetch and store Validator and Nominator slashes for last era
+    const eraSlahes = await api.derive.staking.eraSlashes(eraIndex);
+    const eraValidatorSlashes = eraSlahes.validators;
+    const eraNominatorSlashes = eraSlahes.nominators;
+
+    for (const validator in eraValidatorSlashes) {
+      const amount = eraValidatorSlashes[validator].toString();
+      const sqlInsert = `INSERT INTO validator_slashes_era (block_number, era_index, account_id, amount, timestamp) 
+      VALUES ('${blockNumber}', '${eraIndex}', '${validator}', '${amount}', extract(epoch from now()));`;
+      try {
+        console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[32m=> Adding validator slash for ${validator} in era ${eraIndex}: ${new BigNumber(amount).dividedBy(1e12).toNumber().toFixed(3)} KSM\x1b[0m`);
+        const res = await pool.query(sqlInsert);
+      } catch (error) {
+        console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[31mSQL: ${sqlInsert}\x1b[0m`);
+        console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[31mERROR: ${JSON.stringify(error)}\x1b[0m`);
+      }
+    }
+
+    for (const nominator in eraNominatorSlashes) {
+      const amount = eraNominatorSlashes[nominator].toString();
+      const sqlInsert = `INSERT INTO nominator_slashes_era (block_number, era_index, account_id, amount, timestamp) 
+      VALUES ('${blockNumber}', '${eraIndex}', '${nominator}', '${amount}', extract(epoch from now()));`;
+      try {
+        console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[32m=> Adding nominator slash for ${nominator} in era ${eraIndex}: ${new BigNumber(amount).dividedBy(1e12).toNumber().toFixed(3)} KSM\x1b[0m`);
+        const res = await pool.query(sqlInsert);
+      } catch (error) {
+        console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[31mSQL: ${sqlInsert}\x1b[0m`);
+        console.log(`[PolkaStats backend v3] - Rewards crawler - \x1b[31mERROR: ${JSON.stringify(error)}\x1b[0m`);
+      }
+    }
 
     // Get last era points
     let eraPoints = await api.query.staking.erasRewardPoints(eraIndex);


### PR DESCRIPTION
Closes #132

**Description:**

Store validator and nominator slashes in db for new eras.

Add tables:

- validator_slashes_era
- nominator_slashes_era

**NOTE**: We need to implement fetch and store of rewards and slashes for previous eras (up to history depth) but **not in this PR.**

Thank you! 🚀

---

For contributor:

- [ ] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI