### PR TITLE
Fix wrong timestamp on blocks

### DIFF
--- a/lib/crawlers/blockHarvester.js
+++ b/lib/crawlers/blockHarvester.js
@@ -161,8 +161,8 @@ module.exports = {
         // Get runtime spec name and version
         const runtimeVersion = await api.rpc.state.getRuntimeVersion(blockHash);
         
-        // We can't get the timestamp for old blocks so we put the harvest timestap
-        const timestamp = new Date().getTime();
+        const timestampMs = await api.query.timestamp.now.at(blockHash);
+        const timestamp = Math.floor(timestampMs / 1000);
           
         // Total events
         const totalEvents = blockEvents.length || 0;

--- a/lib/crawlers/blockListener.js
+++ b/lib/crawlers/blockListener.js
@@ -99,7 +99,10 @@ module.exports = {
 
         // Store new block
         console.log(`[PolkaStats backend v3] - Block listener - \x1b[32mAdding block #${blockNumber} (${shortHash(blockHash.toString())})\x1b[0m`);
-        const timestamp = await api.query.timestamp.now();
+        
+        const timestampMs = await api.query.timestamp.now.at(blockHash);
+        const timestamp = Math.floor(timestampMs / 1000);
+
         const sqlInsert =
           `INSERT INTO block (
             block_number,


### PR DESCRIPTION
Use actual created block timestamp instead timestamp.now()

---

For contributor:

- [x] Reviewed `Files changed` in the github PR explorer
- [ ] Attach screenshots of the UI components on the PR description (if applicable)
- [ ] Scope of work approved for big PRs

For reviewer:

- [ ] Manually tested the changes on the UI

---

Fixes #144 